### PR TITLE
dockerization

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.dockerignore
+SDK
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM mono:5.12.0.226 AS webminerpool-build
+
+ARG DONATION_LEVEL=0.03
+
+COPY server /server
+COPY hash_cn /hash_cn
+
+RUN sed -ri "s/^(.*DonationLevel = )[0-9]\.[0-9]{2}/\1${DONATION_LEVEL}/" /server/Server/DevDonation.cs && \
+	apt-get -qq update && \
+	apt-get -qq install build-essential && \
+	cd /hash_cn/libhash && \
+	make && \
+	cd /server && \
+	msbuild Server.sln /p:Configuration=Release_Server /p:Platform="any CPU"
+
+FROM mono:5.12.0.226
+
+VOLUME ["/root"]
+
+RUN mkdir /webminerpool
+COPY entrypoint.sh /entrypoint.sh
+COPY --from=webminerpool-build /server/Server/bin/Release_Server/server.exe /webminerpool
+COPY --from=webminerpool-build /server/Server/bin/Release_Server/pools.json /webminerpool
+COPY --from=webminerpool-build /hash_cn/libhash/libhash.so /webminerpool
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["./entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+# Check if $DOMAIN is set
+if [ -z $DOMAIN ]; then
+	echo -e "You need to set \$DOMAIN variable at run time\n"
+	echo -e "For example: docker run -d -p 80:80 -p 443:443 -e DOMAIN=example.com\n"
+	exit 1
+else
+	# Install acme.sh
+	apt-get -qq update
+	apt-get install -qq \
+		cron \
+		openssl \
+		curl \
+		coreutils \
+		socat \
+		git
+	git clone https://github.com/Neilpang/acme.sh.git /root/acme.sh && \
+	cd /root/acme.sh && \
+	git checkout 2.7.8 && \
+	/root/acme.sh/acme.sh --install
+
+	# Generate SSL cert
+	/root/.acme.sh/acme.sh --issue --standalone -d ${DOMAIN} -d www.${DOMAIN}
+
+	# Generate pfx
+	openssl pkcs12 -export -out /webminerpool/certificate.pfx -inkey /root/.acme.sh/${DOMAIN}/${DOMAIN}.key -in /root/.acme.sh/${DOMAIN}/${DOMAIN}.cer -certfile /root/.acme.sh/${DOMAIN}/fullchain.cer -passin pass:miner -passout pass:miner
+
+	# Start server
+	pushd /webminerpool
+	exec /usr/bin/mono server.exe 
+
+fi


### PR DESCRIPTION
Added `Dockerfile` and `entrypoint.sh`
Inside entrypoint.sh, a certificate is installed so you need to provide a domain name during docker run.
The certificate is automatically renew using a cronjob. The certificate is not renew every time you run the container cause it uses a volume to persist this data.

To build server:
```
cd webminerpool
docker build -t webminerpool {--build-arg DONATION_LEVEL=0.05} .
```
To run it:
```
docker run -d -p 80:80 -p 8181:8181 -e DOMAIN=mydomain.com webminerpool
```
You absolutely need to set a domain name.
The 80:80 bind is used to obtain a certificate.
The 8181:8181 bind is used for server itself.

If you want to bind these ports to a specific IP, you can do this:
```
docker run -d -p xx.xx.xx.xx:80:80 -p xx.xx.xx.xx:8181:8181 -e DOMAIN=mydomain.com webminerpool
```
