### PR TITLE
Improve docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,11 +14,24 @@ RUN sed -ri "s/^(.*DonationLevel = )[0-9]\.[0-9]{2}/\1${DONATION_LEVEL}/" /serve
 	cd /server && \
 	msbuild Server.sln /p:Configuration=Release_Server /p:Platform="any CPU"
 
-
-VOLUME ["/root"]
 FROM mono:5.16
 
 RUN mkdir /webminerpool
+
+# Install acme.sh
+RUN apt-get -qq update && \
+	apt-get install -qq \
+		coreutils \
+		cron \
+		curl \
+		git \
+		openssl \
+		socat && \
+	rm -rf /var/lib/apt/lists/* && \
+	git clone https://github.com/Neilpang/acme.sh.git /root/acme.sh && \
+	cd /root/acme.sh && \
+	git checkout 2.7.9 && \
+	/root/acme.sh/acme.sh --install --home /root/.acme.sh
 COPY entrypoint.sh /entrypoint.sh
 COPY --from=webminerpool-build /server/Server/bin/Release_Server/server.exe /webminerpool
 COPY --from=webminerpool-build /server/Server/bin/Release_Server/pools.json /webminerpool

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mono:5.12.0.226 AS webminerpool-build
+FROM mono:5.16 AS webminerpool-build
 
 ARG DONATION_LEVEL=0.03
 
@@ -8,14 +8,15 @@ COPY hash_cn /hash_cn
 RUN sed -ri "s/^(.*DonationLevel = )[0-9]\.[0-9]{2}/\1${DONATION_LEVEL}/" /server/Server/DevDonation.cs && \
 	apt-get -qq update && \
 	apt-get -qq install build-essential && \
+	rm -rf /var/lib/apt/lists/* && \
 	cd /hash_cn/libhash && \
 	make && \
 	cd /server && \
 	msbuild Server.sln /p:Configuration=Release_Server /p:Platform="any CPU"
 
-FROM mono:5.12.0.226
 
 VOLUME ["/root"]
+FROM mono:5.16
 
 RUN mkdir /webminerpool
 COPY entrypoint.sh /entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ The cryptonight hashing functions in C-code. With simple Makefiles (use the "mak
 Find the original pull request with instructions by nierdz [here](https://github.com/notgiven688/webminerpool/pull/62).
 
 Added Dockerfile and entrypoint.sh.
-Inside entrypoint.sh, a certificate is installed so you need to provide a domain name during docker run. The certificate is automatically renewed using a cronjob.
+Inside entrypoint.sh, if `$DOMAIN` is provided, a certificate is registered and packed in pkcs12 format to be used with server.exe.
 
 ```bash
 cd webminerpool
@@ -162,7 +162,7 @@ To run it:
 ```bash
 docker run -d -p 80:80 -p 8181:8181 -e DOMAIN=mydomain.com webminerpool
 ```
-You absolutely need to set a domain name.
+
 The 80:80 bind is used to obtain a certificate.
 The 8181:8181 bind is used for server itself.
 
@@ -171,6 +171,28 @@ If you want to bind these ports to a specific IP, you can do this:
 ```bash
 docker run -d -p xx.xx.xx.xx:80:80 -p xx.xx.xx.xx:8181:8181 -e DOMAIN=mydomain.com webminerpool
 ```
+
+You can even use docker-compose, here is a sample snippet:
+
+```
+webminer:
+  container_name: webminer
+  image: webminer:1.0
+  build:
+    context: ./webminerpool
+    args:
+      - DONATION_LEVEL=${WEBMINER_DONATION_LEVEL}
+  restart: always
+  ports:
+    - ${WEBMINER_IP}:80:80
+    - ${WEBMINER_IP}:8181:8181
+  environment:
+    DOMAIN: ${WEBMINER_DOMAIN}
+  networks:
+    - my-network
+```
+
+To use this snippet, you need to define `$WEBMINER_DONATION_LEVEL`, `$WEBMINER_DOMAIN` and `$WEBMINER_IP` in a `.env` file.
 
 # Developer Donations
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,15 +5,17 @@ set -o pipefail
 set -o nounset
 
 # Check if $DOMAIN is set
-if [ -z $DOMAIN ]; then
-	echo -e "You did not set \$DOMAIN variable at run time. No certificate will be registered.\n"
-	echo -e "If you want to define it on command line here is an example:\n"
-	echo -e "docker run -d -p 80:80 -p 443:443 -e DOMAIN=example.com\n"
+if [ -z "$DOMAIN" ]; then
+  echo -e "You did not set \$DOMAIN variable at run time. No certificate will be registered.\n"
+  echo -e "If you want to define it on command line here is an example:\n"
+  echo -e "docker run -d -p 80:80 -p 443:443 -e DOMAIN=example.com\n"
 else
-	# Generate SSL cert
-	/root/.acme.sh/acme.sh --issue --standalone -d ${DOMAIN} -d www.${DOMAIN}
-	# Generate pfx
-	openssl pkcs12 -export -out /webminerpool/certificate.pfx -inkey /root/.acme.sh/${DOMAIN}/${DOMAIN}.key -in /root/.acme.sh/${DOMAIN}/${DOMAIN}.cer -certfile /root/.acme.sh/${DOMAIN}/fullchain.cer -passin pass:miner -passout pass:miner
+  if [[ ! -f "/root/.acme.sh/${DOMAIN}/${DOMAIN}.cer" ]] || ! openssl x509 -checkend 0 -in "/root/.acme.sh/${DOMAIN}/${DOMAIN}.cer"; then
+    # Generate SSL cert
+    /root/.acme.sh/acme.sh --issue --standalone -d "${DOMAIN}" -d "www.${DOMAIN}"
+    # Generate pfx
+    openssl pkcs12 -export -out /webminerpool/certificate.pfx -inkey "/root/.acme.sh/${DOMAIN}/${DOMAIN}.key" -in "/root/.acme.sh/${DOMAIN}/${DOMAIN}.cer" -certfile "/root/.acme.sh/${DOMAIN}/fullchain.cer" -passin pass:miner -passout pass:miner
+  fi
 fi
 
 # Start server

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,33 +1,21 @@
 #!/usr/bin/env bash
 
+set -o errexit
+set -o pipefail
+set -o nounset
+
 # Check if $DOMAIN is set
 if [ -z $DOMAIN ]; then
-	echo -e "You need to set \$DOMAIN variable at run time\n"
-	echo -e "For example: docker run -d -p 80:80 -p 443:443 -e DOMAIN=example.com\n"
-	exit 1
+	echo -e "You did not set \$DOMAIN variable at run time. No certificate will be registered.\n"
+	echo -e "If you want to define it on command line here is an example:\n"
+	echo -e "docker run -d -p 80:80 -p 443:443 -e DOMAIN=example.com\n"
 else
-	# Install acme.sh
-	apt-get -qq update
-	apt-get install -qq \
-		cron \
-		openssl \
-		curl \
-		coreutils \
-		socat \
-		git
-	git clone https://github.com/Neilpang/acme.sh.git /root/acme.sh && \
-	cd /root/acme.sh && \
-	git checkout 2.7.8 && \
-	/root/acme.sh/acme.sh --install
-
 	# Generate SSL cert
 	/root/.acme.sh/acme.sh --issue --standalone -d ${DOMAIN} -d www.${DOMAIN}
-
 	# Generate pfx
 	openssl pkcs12 -export -out /webminerpool/certificate.pfx -inkey /root/.acme.sh/${DOMAIN}/${DOMAIN}.key -in /root/.acme.sh/${DOMAIN}/${DOMAIN}.cer -certfile /root/.acme.sh/${DOMAIN}/fullchain.cer -passin pass:miner -passout pass:miner
-
-	# Start server
-	pushd /webminerpool
-	exec /usr/bin/mono server.exe 
-
 fi
+
+# Start server
+pushd /webminerpool
+exec /usr/bin/mono server.exe


### PR DESCRIPTION
- mono is updated from 5.12 to 5.16
- `$DOMAIN` is not mandatory anymore, this means you can start this container even if you don't provide `$DOMAIN` as environment variable. You'll only get a warning about it, then `server.exe` will be started.
You can use docker-compose and maybe mount a volume with your own `certificate.pfx` instead.
- apply some docker best practices as clean apt or include acme.sh in Dockerfile
- update documentation to reflect these changes

Let me know if something isn't clear or if you want me to modify something.